### PR TITLE
Change controller for the ingress class from `ingress-nginx` to `ngin…

### DIFF
--- a/controllers/ingress_class_creator.go
+++ b/controllers/ingress_class_creator.go
@@ -48,7 +48,7 @@ func (icc IngressClassCreator) CreateIngressClass(logger logr.Logger) error {
 			Name: icc.ClassName,
 		},
 		Spec: networking.IngressClassSpec{
-			Controller: "k8s.io/ingress-nginx",
+			Controller: "k8s.io/nginx-ingress",
 		},
 	}
 

--- a/controllers/ingress_class_creator_test.go
+++ b/controllers/ingress_class_creator_test.go
@@ -56,7 +56,7 @@ func TestIngressClassCreator_CreateIngressClass(t *testing.T) {
 				Name: "myIngressClass",
 			},
 			Spec: networking.IngressClassSpec{
-				Controller: "k8s.io/ingress-nginx",
+				Controller: "k8s.io/nginx-ingress",
 			},
 		}
 		clientMock := testclient.NewClientBuilder().WithScheme(getScheme()).WithObjects(ingressClass).Build()


### PR DESCRIPTION
…x-ingress`

This is a required operation as we renamed our nginx ingress from `ingress-nginx`
to `nginx-ingress`. Otherwise, the `nginx-ingress` would ignore all created ingress
objects.