### PR TITLE
Fix maintenance mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#38] deprecation warning for argument `logtostderr` in kube-rbac-proxy
+- [#44] Fix a bug where the service discovery only updated one single ingress switching maintenance mode.
 
 ### Removed
 - [#38] deprecated argument `logtostderr` from kube-rbac-proxy

--- a/controllers/maintenanceModeUpdater.go
+++ b/controllers/maintenanceModeUpdater.go
@@ -167,7 +167,8 @@ func (scu *maintenanceModeUpdater) getAllServices(ctx context.Context) (v1Servic
 
 	var modifiableServiceList v1ServiceList
 	for _, svc := range serviceList.Items {
-		modifiableServiceList = append(modifiableServiceList, &svc)
+		copySvc := svc
+		modifiableServiceList = append(modifiableServiceList, &copySvc)
 	}
 
 	return modifiableServiceList, nil


### PR DESCRIPTION
Copy reference in for loop selection so that the loop does not override the injected service.

Resolves #44 